### PR TITLE
chore: align Claude and Cursor AI config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,6 +20,7 @@
 - `src/lib/` — shared utilities and business logic
 - `src/types/` — shared TypeScript types and declarations
 - `src/app/` — Next.js App Router pages and API routes
+- `e2e/` — Playwright E2E (`e2e/tests/**/*.e2e.ts`), auth setup, fixtures, seed helpers
 
 ## Key Rules
 
@@ -28,6 +29,7 @@
 - New database queries go in the relevant file in `src/db/` — never inline in components
 - Client components (`"use client"`) go in `src/clientComponents/`, not `src/components/`
 - API routes go under `src/app/api/`
+- New **user-facing** features should include **Playwright** tests (`*.e2e.ts` under `e2e/tests/`) and **Vitest** for units/components (`*.spec.ts` / `*.spec.tsx` in `src/`)
 
 ## Imports
 
@@ -61,7 +63,12 @@ vi.mock('@/db/client', () => ({
 }))
 ```
 
+## Work quality
+
+- Do not leave **TODO** comments — implement, remove, or track outside the codebase.
+- Do not consider work complete until **`npm run pipeline:check`** passes.
+
 ## Verification
 
-- Run `npm run pipeline:check` after every change
-- This runs: lint → format:check → type-check → test:coverage → test:e2e → build
+- Run `npm run fix:all` after substantive edits (ESLint + Prettier, including `e2e/**/*.ts` and `playwright.config.ts`).
+- Run `npm run pipeline:check` before finishing — lint → format:check → type-check → test:coverage → test:e2e → build

--- a/.claude/commands/gentypes.md
+++ b/.claude/commands/gentypes.md
@@ -1,4 +1,6 @@
 Regenerate the Supabase TypeScript types by running:
 `npx supabase gen types typescript --project-id "zfznuscqncvujhzjzinc" --schema public > src/types/database.ts`
 
+After successful gen types, ensure the change to the comment at the top of the file is reverted
+
 Never manually edit `src/types/database.ts`.

--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -1,10 +1,12 @@
-Run the following commands in order:
+Run the following commands in order (same as `npm run pipeline:check`):
 
 1. `npm run lint`
 2. `npm run format:check`
 3. `npm run type-check`
 4. `npm run test:coverage`
-5. `npm run build`
+5. `npm run test:e2e`
+6. `npm run build`
 
-If any step fails, fix the issues and re-run that step.
-Do not consider the current task complete until all five pass cleanly.
+If any step fails, fix the issues and re-run from that step (or re-run the full pipeline).
+
+Do not consider the current task complete until all six pass cleanly.

--- a/.cursor/rules/hshb-core.mdc
+++ b/.cursor/rules/hshb-core.mdc
@@ -42,6 +42,10 @@ alwaysApply: true
 - All imports must be at the top of the file, before any other code
 - Never add imports inline or mid-file — always place them with the existing import block
 
+## Work quality
+
+Matches global Claude Code conventions: do not leave **TODO** comments in code — implement, remove, or track work outside the repo. Do not consider a task **complete** until **`npm run pipeline:check`** passes (fix all failures before moving on).
+
 ## Verification
 
 - Run `npm run fix:all` after every change — `lint:fix` covers `src/`, `e2e/**/*.ts`, and `playwright.config.ts`; `format` runs Prettier on the repo (including `*.e2e.ts`).

--- a/.cursor/rules/hshb-supabase.mdc
+++ b/.cursor/rules/hshb-supabase.mdc
@@ -16,4 +16,5 @@ alwaysApply: false
 
 - `src/types/database.ts` is auto-generated — NEVER edit it manually
 - To regenerate after schema changes, use the Supabase MCP `generate_typescript_types` tool
-- Or run manually: `npx supabase gen types typescript --schema public > src/types/database.ts`
+- **Local** (CLI linked to local Supabase): `npx supabase gen types typescript --schema public > src/types/database.ts`
+- **Remote project** (matches `.claude/commands/gentypes.md`): `npx supabase gen types typescript --project-id "zfznuscqncvujhzjzinc" --schema public > src/types/database.ts`

--- a/.cursor/rules/hshb-testing.mdc
+++ b/.cursor/rules/hshb-testing.mdc
@@ -12,6 +12,7 @@ alwaysApply: false
 - Test files use `.spec.tsx` / `.spec.ts` suffix alongside the source file
 - Component tests use React Testing Library
 - Never use `jest.mock()` — always use `vi.mock()`, `vi.spyOn()` or `vi.fn()`
+- **Mock factories** and test-only helpers: keep them in the **same spec file** unless reused across multiple tests — then colocate a small shared helper next to those specs (avoid a sprawling `__mocks__` tree without need).
 
 ## Supabase in tests
 

--- a/.cursor/rules/hshb-typescript.mdc
+++ b/.cursor/rules/hshb-typescript.mdc
@@ -11,8 +11,9 @@ Applies to `src/**`. **Not** for Vitest/Playwright files outside `src/`; skip **
 ## Strictness
 
 - Avoid **`any`**. Prefer **`unknown`** and narrow, **`satisfies`**, or explicit domain types from `@/types` / inferred from Zod (`z.infer`).
+- Prefer **`type` over `interface`** unless you need declaration merging or a clear `extends` pattern that reads better as an interface.
 - **`eslint-disable` for TypeScript** is a last resort — fix the type or the API shape instead.
-- **Exported** functions and public hooks: prefer **explicit return types** when inference is wide, opaque, or unstable across edits.
+- **Explicit return types** on **named functions** (exports, hooks, and module-scope helpers). Narrow inline callbacks (`map`, `then`, etc.) may rely on inference when obvious.
 
 ## Boundaries
 


### PR DESCRIPTION
Aligns project Cursor rules with Claude Code preferences and fixes the verify command to match `pipeline:check`.

**Cursor rules**
- `hshb-core`: work quality (no TODOs, gate on pipeline), references global Claude conventions
- `hshb-typescript`: `type` vs `interface`, explicit return types on named functions
- `hshb-testing`: mock factories colocated in spec unless shared
- `hshb-supabase`: local and remote `supabase gen types` commands

**Claude project**
- `.claude/CLAUDE.md`: `e2e/` folder, Playwright + Vitest expectation, `fix:all`, work quality
- `.claude/commands/verify.md`: add `test:e2e`, six steps to match `npm run pipeline:check`

Made with [Cursor](https://cursor.com)