### PR TITLE
feat(time handling): improve the handling for timezone entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   ci:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:

--- a/src/app/portal/attendance/AttendanceRegister.tsx
+++ b/src/app/portal/attendance/AttendanceRegister.tsx
@@ -1,6 +1,7 @@
 import BulkEmailDropdown from '@/clientComponents/BulkEmailDropdown'
 import { getStudentsByClass, getAttendanceByClassAndDate } from '@/db'
 import type { AttendanceStatus } from '@/db'
+import { todayInSchoolTz } from '@/lib/datetime'
 import { guardianEmailsForMailto, mailtoWithBcc } from '@/lib/mailto'
 import type { StaffRole } from '@/types/next-auth'
 
@@ -29,7 +30,7 @@ export default async function AttendanceRegister({
     existing[row.student_id] = row.status as AttendanceStatus
   }
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = todayInSchoolTz()
   const dateLabel =
     date === today ? 'Today' : date < today ? 'Historical' : 'Future'
 

--- a/src/app/portal/attendance/page.tsx
+++ b/src/app/portal/attendance/page.tsx
@@ -3,6 +3,7 @@ import { type Metadata } from 'next'
 
 import { auth } from '@/auth'
 import { getAllClasses, getClassesByTeacher } from '@/db'
+import { todayInSchoolTz } from '@/lib/datetime'
 import { isTeacher } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 
@@ -57,7 +58,7 @@ export default async function AttendancePage({
 
   const { classId: qClassId, date: qDate } = await searchParams
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = todayInSchoolTz()
   const selectedDate = qDate ?? today
 
   const classes = isTeacher(role)

--- a/src/app/portal/dashboard/page.tsx
+++ b/src/app/portal/dashboard/page.tsx
@@ -19,6 +19,7 @@ import {
   getAttendanceSummaryByDate,
   getStaffSignedInCount,
 } from '@/db'
+import { todayInSchoolTz } from '@/lib/datetime'
 import { isTeacher } from '@/lib/permissions'
 import { roleLabels } from '@/lib/roleLabels'
 import type { StaffRole } from '@/types/next-auth'
@@ -33,7 +34,7 @@ export default async function DashboardPage() {
   const role = session?.user?.role as StaffRole
   const staffId = session?.user?.staffId
   const teacherOnly = isTeacher(role)
-  const today = new Date().toISOString().split('T')[0]
+  const today = todayInSchoolTz()
 
   const [
     studentCount,

--- a/src/app/portal/incidents/IncidentsClient.tsx
+++ b/src/app/portal/incidents/IncidentsClient.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 
 import type { IncidentRow, IncidentType } from '@/db'
+import { formatDateInSchoolTz } from '@/lib/datetime'
 import { isTeacher } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 import Tooltip from '@/components/Tooltip'
@@ -85,9 +86,7 @@ export default function IncidentsClient({ incidents, role, canEdit }: Props) {
                       {incident.student.first_name}
                     </p>
                     <p className="text-xs text-gray-500">
-                      {new Date(incident.incident_date).toLocaleDateString(
-                        'en-GB',
-                      )}
+                      {formatDateInSchoolTz(incident.incident_date)}
                     </p>
                   </div>
                   {canEdit ? (
@@ -127,9 +126,7 @@ export default function IncidentsClient({ incidents, role, canEdit }: Props) {
                   <span>
                     Guardians notified:{' '}
                     {incident.parent_notified_at
-                      ? new Date(
-                          incident.parent_notified_at,
-                        ).toLocaleDateString('en-GB')
+                      ? formatDateInSchoolTz(incident.parent_notified_at)
                       : incident.parent_notified
                         ? 'Yes'
                         : 'No'}
@@ -168,9 +165,7 @@ export default function IncidentsClient({ incidents, role, canEdit }: Props) {
                   {filtered.map((incident) => (
                     <tr key={incident.id} className="hover:bg-gray-50">
                       <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900">
-                        {new Date(incident.incident_date).toLocaleDateString(
-                          'en-GB',
-                        )}
+                        {formatDateInSchoolTz(incident.incident_date)}
                       </td>
                       <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-900">
                         {incident.student.last_name},{' '}
@@ -198,9 +193,7 @@ export default function IncidentsClient({ incidents, role, canEdit }: Props) {
                       </td>
                       <td className="px-6 py-4 text-sm whitespace-nowrap text-gray-500">
                         {incident.parent_notified_at
-                          ? new Date(
-                              incident.parent_notified_at,
-                            ).toLocaleDateString('en-GB')
+                          ? formatDateInSchoolTz(incident.parent_notified_at)
                           : incident.parent_notified
                             ? 'Yes'
                             : '—'}

--- a/src/app/portal/incidents/[id]/edit/EditIncidentForm.tsx
+++ b/src/app/portal/incidents/[id]/edit/EditIncidentForm.tsx
@@ -4,18 +4,15 @@ import { useState, useTransition } from 'react'
 import Link from 'next/link'
 
 import type { IncidentRow } from '@/db'
+import {
+  nowDatetimeLocalInSchoolTz,
+  toDatetimeLocalInSchoolTz,
+} from '@/lib/datetime'
 
 import { updateIncidentAction } from '../../actions'
 
 type Props = {
   incident: IncidentRow
-}
-
-function localNow() {
-  const now = new Date()
-  return new Date(now.getTime() - now.getTimezoneOffset() * 60000)
-    .toISOString()
-    .slice(0, 16)
 }
 
 export default function EditIncidentForm({ incident }: Props) {
@@ -38,12 +35,12 @@ export default function EditIncidentForm({ incident }: Props) {
   }
 
   const defaultDateTime = incident.incident_date
-    ? incident.incident_date.slice(0, 16)
+    ? toDatetimeLocalInSchoolTz(incident.incident_date)
     : ''
 
   const defaultNotifiedAt = incident.parent_notified_at
-    ? incident.parent_notified_at.slice(0, 16)
-    : localNow()
+    ? toDatetimeLocalInSchoolTz(incident.parent_notified_at)
+    : nowDatetimeLocalInSchoolTz()
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">

--- a/src/app/portal/incidents/actions.ts
+++ b/src/app/portal/incidents/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache'
 
 import { auth } from '@/auth'
 import { createIncident, updateIncident, logAuditEvent } from '@/db'
+import { datetimeLocalToUtcIso } from '@/lib/datetime'
 import { getUserFriendlyDbError } from '@/lib/db-error'
 import { canEditIncidents } from '@/lib/permissions'
 import {
@@ -25,16 +26,21 @@ export async function createIncidentAction(
   const parsed = createIncidentSchema.safeParse(raw)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const { type, parent_notified, parent_notified_at, ...rest } = parsed.data
+  const { type, parent_notified, parent_notified_at, incident_date, ...rest } =
+    parsed.data
   const created_by = session.user.staffId!
 
   try {
     const incident = await createIncident({
       type,
       ...rest,
+      incident_date: datetimeLocalToUtcIso(incident_date),
       created_by,
       parent_notified,
-      parent_notified_at: parent_notified ? parent_notified_at : null,
+      parent_notified_at:
+        parent_notified && parent_notified_at
+          ? datetimeLocalToUtcIso(parent_notified_at)
+          : null,
     })
     logAuditEvent({
       staffId: created_by,
@@ -69,15 +75,20 @@ export async function updateIncidentAction(
   const parsed = updateIncidentSchema.safeParse(raw)
   if (!parsed.success) return { error: parsed.error.issues[0].message }
 
-  const { type, parent_notified, parent_notified_at, ...rest } = parsed.data
+  const { type, parent_notified, parent_notified_at, incident_date, ...rest } =
+    parsed.data
   const updated_by = session.user.staffId!
 
   try {
     await updateIncident(id, {
       ...rest,
+      incident_date: datetimeLocalToUtcIso(incident_date),
       updated_by,
       parent_notified,
-      parent_notified_at: parent_notified ? parent_notified_at : null,
+      parent_notified_at:
+        parent_notified && parent_notified_at
+          ? datetimeLocalToUtcIso(parent_notified_at)
+          : null,
     })
     logAuditEvent({
       staffId: updated_by,

--- a/src/app/portal/incidents/new/AddIncidentForm.tsx
+++ b/src/app/portal/incidents/new/AddIncidentForm.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition, useRef, useEffect } from 'react'
 import Link from 'next/link'
 
 import type { IncidentType } from '@/db'
+import { nowDatetimeLocalInSchoolTz } from '@/lib/datetime'
 
 import { createIncidentAction } from '../actions'
 
@@ -13,13 +14,6 @@ type Props = {
   students: StudentSummary[]
   staffId: string
   type: IncidentType
-}
-
-function localNow() {
-  const now = new Date()
-  return new Date(now.getTime() - now.getTimezoneOffset() * 60000)
-    .toISOString()
-    .slice(0, 16)
 }
 
 export default function AddIncidentForm({ students, type }: Props) {
@@ -98,7 +92,7 @@ export default function AddIncidentForm({ students, type }: Props) {
             name="incident_date"
             type="datetime-local"
             required
-            defaultValue={localNow()}
+            defaultValue={nowDatetimeLocalInSchoolTz()}
           />
         </div>
       </div>
@@ -126,7 +120,7 @@ export default function AddIncidentForm({ students, type }: Props) {
               label="Date & time notified"
               name="parent_notified_at"
               type="datetime-local"
-              defaultValue={localNow()}
+              defaultValue={nowDatetimeLocalInSchoolTz()}
             />
           </div>
         )}

--- a/src/app/portal/lesson-plans/LessonPlansClient.tsx
+++ b/src/app/portal/lesson-plans/LessonPlansClient.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 
 import type { LessonPlanRow } from '@/db'
+import { formatCalendarDate, formatDateTimeInSchoolTz } from '@/lib/datetime'
 import { isTeacher } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 import Tooltip from '@/components/Tooltip'
@@ -17,7 +18,7 @@ type Props = {
 }
 
 function formatDate(dateStr: string) {
-  return new Date(dateStr + 'T00:00:00').toLocaleDateString('en-GB')
+  return formatCalendarDate(dateStr)
 }
 
 export default function LessonPlansClient({
@@ -247,7 +248,7 @@ function LessonPlanModal({
                 {plan.creator.first_name} {plan.creator.last_name}
               </p>
               <p className="text-xs text-gray-400">
-                {new Date(plan.created_at).toLocaleString('en-GB')}
+                {formatDateTimeInSchoolTz(plan.created_at)}
               </p>
               {plan.updater && (
                 <>
@@ -258,7 +259,7 @@ function LessonPlanModal({
                     {plan.updater.first_name} {plan.updater.last_name}
                   </p>
                   <p className="text-xs text-gray-400">
-                    {new Date(plan.updated_at).toLocaleString('en-GB')}
+                    {formatDateTimeInSchoolTz(plan.updated_at)}
                   </p>
                 </>
               )}

--- a/src/app/portal/lesson-plans/new/AddLessonPlanForm.tsx
+++ b/src/app/portal/lesson-plans/new/AddLessonPlanForm.tsx
@@ -3,6 +3,8 @@
 import { useState, useTransition } from 'react'
 import Link from 'next/link'
 
+import { todayInSchoolTz } from '@/lib/datetime'
+
 import { createLessonPlanAction } from '../actions'
 
 type ClassSummary = { id: string; name: string; year_group: string }
@@ -12,7 +14,7 @@ type Props = {
 }
 
 function todayDate() {
-  return new Date().toISOString().slice(0, 10)
+  return todayInSchoolTz()
 }
 
 export default function AddLessonPlanForm({ classes }: Props) {

--- a/src/app/portal/reports/_components/PeriodReport.tsx
+++ b/src/app/portal/reports/_components/PeriodReport.tsx
@@ -1,4 +1,5 @@
 import type { IncidentCounts } from '@/db'
+import { formatCalendarDate } from '@/lib/datetime'
 
 import SectionCard from '../../_components/SectionCard'
 
@@ -32,9 +33,10 @@ const TH =
   'px-6 py-3 text-left text-xs font-medium tracking-wide text-gray-500 uppercase'
 
 function formatDateShort(dateStr: string): string {
-  const d = new Date(dateStr + 'T12:00:00')
-  const day = d.toLocaleDateString('en-GB', { weekday: 'short' })
-  return `${day} ${d.getDate()}`
+  const day = formatCalendarDate(dateStr, { weekday: 'short' })
+  const match = dateStr.match(/^\d{4}-\d{2}-(\d{2})/)
+  const dayOfMonth = match ? Number(match[1]) : ''
+  return `${day} ${dayOfMonth}`
 }
 
 function pct(n: number, total: number): string {

--- a/src/app/portal/reports/_components/SchoolDaysCard.tsx
+++ b/src/app/portal/reports/_components/SchoolDaysCard.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 
+import { formatCalendarDate } from '@/lib/datetime'
+
 export type SchoolDayDate = {
   date: string
   staffCount: number
@@ -15,7 +17,7 @@ type Props = {
 }
 
 function formatDateFull(dateStr: string): string {
-  return new Date(dateStr + 'T12:00:00').toLocaleDateString('en-GB', {
+  return formatCalendarDate(dateStr, {
     weekday: 'short',
     day: 'numeric',
     month: 'short',

--- a/src/app/portal/reports/page.tsx
+++ b/src/app/portal/reports/page.tsx
@@ -2,6 +2,11 @@ import { type Metadata } from 'next'
 import { redirect } from 'next/navigation'
 
 import { auth } from '@/auth'
+import {
+  formatCalendarDate,
+  formatTimeInSchoolTz,
+  todayInSchoolTz,
+} from '@/lib/datetime'
 import { canAccessReports, isTeachingStaff } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 import {
@@ -42,7 +47,7 @@ export default async function ReportsPage({
     redirect('/portal/dashboard')
   }
 
-  const today = new Date().toISOString().split('T')[0]
+  const today = todayInSchoolTz()
   const params = await searchParams
 
   const mode: ReportMode =
@@ -53,11 +58,13 @@ export default async function ReportsPage({
   const selectedMonth = params.month ?? today.slice(0, 7)
   const [yearNum, monthNum] = selectedMonth.split('-').map(Number)
   const monthStart = `${yearNum}-${String(monthNum).padStart(2, '0')}-01`
-  const monthEnd = new Date(yearNum, monthNum, 0).toISOString().split('T')[0]
+  const monthEnd = new Date(Date.UTC(yearNum, monthNum, 0))
+    .toISOString()
+    .split('T')[0]
 
-  const todayDate = new Date(today + 'T12:00:00')
-  todayDate.setDate(todayDate.getDate() - 7)
-  const sevenDaysAgo = todayDate.toISOString().split('T')[0]
+  const todayAtNoonUtc = new Date(`${today}T12:00:00Z`)
+  todayAtNoonUtc.setUTCDate(todayAtNoonUtc.getUTCDate() - 7)
+  const sevenDaysAgo = todayAtNoonUtc.toISOString().split('T')[0]
   const rangeFrom = params.from ?? sevenDaysAgo
   const rangeTo = params.to ?? today
 
@@ -76,15 +83,12 @@ export default async function ReportsPage({
   let badgeColor = 'bg-amber-500'
 
   if (mode === 'day') {
-    subtitle = new Date(selectedDate + 'T12:00:00').toLocaleDateString(
-      'en-GB',
-      {
-        weekday: 'long',
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      },
-    )
+    subtitle = formatCalendarDate(selectedDate, {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
     if (selectedDate === today) {
       badgeLabel = 'Today'
       badgeColor = 'bg-green-500'
@@ -94,13 +98,13 @@ export default async function ReportsPage({
       badgeLabel = 'Future'
     }
   } else if (mode === 'month') {
-    subtitle = new Date(yearNum, monthNum - 1).toLocaleDateString('en-GB', {
+    subtitle = formatCalendarDate(monthStart, {
       month: 'long',
       year: 'numeric',
     })
   } else {
     const fmtShort = (d: string) =>
-      new Date(d + 'T12:00:00').toLocaleDateString('en-GB', {
+      formatCalendarDate(d, {
         day: 'numeric',
         month: 'short',
         year: 'numeric',
@@ -137,12 +141,6 @@ export default async function ReportsPage({
       0,
     )
 
-    const fmt = (ts: string) =>
-      new Date(ts).toLocaleTimeString('en-GB', {
-        hour: '2-digit',
-        minute: '2-digit',
-      })
-
     const enrolmentByClass = classes.map((cls) => {
       const summary = attendanceSummary[cls.id]
       const enrolled = enrollmentCounts[cls.id] ?? 0
@@ -150,8 +148,12 @@ export default async function ReportsPage({
         name: cls.name,
         enrolled,
         presentCount: summary?.presentCount ?? null,
-        attendanceCreatedAt: summary ? fmt(summary.createdAt) : null,
-        attendanceUpdatedAt: summary ? fmt(summary.updatedAt) : null,
+        attendanceCreatedAt: summary
+          ? formatTimeInSchoolTz(summary.createdAt)
+          : null,
+        attendanceUpdatedAt: summary
+          ? formatTimeInSchoolTz(summary.updatedAt)
+          : null,
       }
     })
 

--- a/src/app/portal/staff-attendance/StaffAttendanceTable.tsx
+++ b/src/app/portal/staff-attendance/StaffAttendanceTable.tsx
@@ -4,11 +4,11 @@ import { useTransition, useState } from 'react'
 
 import type { StaffAttendanceRow } from '@/db'
 import Tooltip from '@/components/Tooltip'
+import { formatTimeInSchoolTz } from '@/lib/datetime'
 import { canManageStaffAttendance } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 
 import { signInAction, signOutAction } from './actions'
-import { fmtTime } from './utils'
 
 export type StaffMember = {
   id: string
@@ -29,13 +29,14 @@ function StatusBadge({ record }: { record: StaffAttendanceRow | null }) {
   if (record.signed_out_at) {
     return (
       <span className="inline-flex items-center rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
-        In {fmtTime(record.signed_in_at)} · Out {fmtTime(record.signed_out_at)}
+        In {formatTimeInSchoolTz(record.signed_in_at)} · Out{' '}
+        {formatTimeInSchoolTz(record.signed_out_at)}
       </span>
     )
   }
   return (
     <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800">
-      Signed In {fmtTime(record.signed_in_at)}
+      Signed In {formatTimeInSchoolTz(record.signed_in_at)}
     </span>
   )
 }

--- a/src/app/portal/staff-attendance/actions.spec.ts
+++ b/src/app/portal/staff-attendance/actions.spec.ts
@@ -10,6 +10,7 @@ vi.mock('@/db', () => ({
   signOutStaff: vi.fn(),
   logAuditEvent: vi.fn(),
 }))
+
 vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
 
 import { signInAction, signOutAction } from './actions'
@@ -58,7 +59,7 @@ describe('signInAction', () => {
     expect(signInStaff).toHaveBeenCalledWith(
       STAFF_1,
       '2026-03-18',
-      '2026-03-18T09:00:00',
+      '2026-03-18T09:00:00.000Z',
     )
     expect(revalidatePath).toHaveBeenCalledWith('/portal/staff-attendance')
   })
@@ -94,7 +95,7 @@ describe('signInAction', () => {
     expect(signInStaff).toHaveBeenCalledWith(
       STAFF_1,
       '2026-03-18',
-      '2026-03-18T09:00:00',
+      '2026-03-18T09:00:00.000Z',
     )
   })
 
@@ -153,7 +154,7 @@ describe('signInAction', () => {
     expect(signInStaff).toHaveBeenCalledWith(
       SECRETARY_1,
       '2026-03-18',
-      '2026-03-18T09:00:00',
+      '2026-03-18T09:00:00.000Z',
     )
     expect(revalidatePath).toHaveBeenCalledWith('/portal/staff-attendance')
   })
@@ -193,7 +194,7 @@ describe('signOutAction', () => {
     expect(signOutStaff).toHaveBeenCalledWith(
       STAFF_1,
       '2026-03-18',
-      '2026-03-18T17:00:00',
+      '2026-03-18T17:00:00.000Z',
     )
     expect(revalidatePath).toHaveBeenCalledWith('/portal/staff-attendance')
   })
@@ -258,7 +259,7 @@ describe('signOutAction', () => {
     expect(signOutStaff).toHaveBeenCalledWith(
       SECRETARY_1,
       '2026-03-18',
-      '2026-03-18T17:00:00',
+      '2026-03-18T17:00:00.000Z',
     )
     expect(revalidatePath).toHaveBeenCalledWith('/portal/staff-attendance')
   })

--- a/src/app/portal/staff-attendance/actions.ts
+++ b/src/app/portal/staff-attendance/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache'
 
 import { auth } from '@/auth'
 import { signInStaff, signOutStaff, logAuditEvent } from '@/db'
+import { schoolTzToUtcIso } from '@/lib/datetime'
 import { getUserFriendlyDbError } from '@/lib/db-error'
 import { canManageStaffAttendance } from '@/lib/permissions'
 import {
@@ -12,10 +13,6 @@ import {
   type ActionResult,
 } from '@/lib/schemas'
 import type { StaffRole } from '@/types/next-auth'
-
-function buildTimestamp(date: string, time: string): string {
-  return `${date}T${time}:00`
-}
 
 export async function signInAction(formData: FormData): Promise<ActionResult> {
   const session = await auth()
@@ -33,7 +30,7 @@ export async function signInAction(formData: FormData): Promise<ActionResult> {
   }
 
   try {
-    await signInStaff(staffId, date, buildTimestamp(date, time))
+    await signInStaff(staffId, date, schoolTzToUtcIso(date, time))
     logAuditEvent({
       staffId: session.user.staffId ?? null,
       action: 'sign_in',
@@ -68,7 +65,7 @@ export async function signOutAction(formData: FormData): Promise<ActionResult> {
   }
 
   try {
-    await signOutStaff(staffId, date, buildTimestamp(date, time))
+    await signOutStaff(staffId, date, schoolTzToUtcIso(date, time))
     logAuditEvent({
       staffId: session.user.staffId ?? null,
       action: 'sign_out',

--- a/src/app/portal/staff-attendance/page.spec.tsx
+++ b/src/app/portal/staff-attendance/page.spec.tsx
@@ -20,10 +20,6 @@ vi.mock('./StaffAttendanceTable', () => ({
   default: vi.fn(() => <div data-testid="staff-table" />),
 }))
 
-vi.mock('./utils', () => ({
-  fmtTime: vi.fn((ts: string) => ts),
-}))
-
 vi.mock('@/components/DatePicker', () => ({
   default: vi.fn(() => <div data-testid="date-picker" />),
 }))
@@ -39,6 +35,7 @@ import {
   getStaffAttendanceByDate,
   getStaffAttendanceForToday,
 } from '@/db'
+import { todayInSchoolTz } from '@/lib/datetime'
 
 import StaffAttendancePage from './page'
 
@@ -156,7 +153,7 @@ describe('StaffAttendancePage', () => {
     it('calls getStaffAttendanceByDate (full staff list, not teacher-only)', async () => {
       render(await StaffAttendancePage({ searchParams: makeSearchParams() }))
 
-      const today = new Date().toISOString().split('T')[0]
+      const today = todayInSchoolTz()
       expect(getStaffAttendanceByDate).toHaveBeenCalledWith(today)
       expect(getStaffAttendanceForToday).not.toHaveBeenCalled()
     })
@@ -185,7 +182,7 @@ describe('StaffAttendancePage', () => {
     it('calls getStaffAttendanceByDate with today by default', async () => {
       render(await StaffAttendancePage({ searchParams: makeSearchParams() }))
 
-      const today = new Date().toISOString().split('T')[0]
+      const today = todayInSchoolTz()
       expect(getStaffAttendanceByDate).toHaveBeenCalledWith(today)
       expect(getStaffAttendanceForToday).not.toHaveBeenCalled()
     })

--- a/src/app/portal/staff-attendance/page.tsx
+++ b/src/app/portal/staff-attendance/page.tsx
@@ -8,13 +8,18 @@ import {
   getStaffAttendanceByDate,
   getStaffAttendanceForToday,
 } from '@/db'
+import {
+  formatCalendarDate,
+  formatTimeInSchoolTz,
+  nowTimeInSchoolTz,
+  todayInSchoolTz,
+} from '@/lib/datetime'
 import { isTeacher, showsOnSignInSheet } from '@/lib/permissions'
 import type { StaffRole } from '@/types/next-auth'
 import DatePicker from '@/components/DatePicker'
 
 import PrintButton from './PrintButton'
 import StaffAttendanceTable from './StaffAttendanceTable'
-import { fmtTime } from './utils'
 
 export const metadata: Metadata = { title: 'Staff Sign-In' }
 
@@ -29,9 +34,8 @@ export default async function StaffAttendancePage({
   const role = session.user?.role as StaffRole
   const staffId = session.user?.staffId ?? ''
 
-  const today = new Date().toISOString().split('T')[0]
-  const now = new Date()
-  const currentTime = `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`
+  const today = todayInSchoolTz()
+  const currentTime = nowTimeInSchoolTz()
 
   if (isTeacher(role)) {
     // Teachers always see today only, for themselves
@@ -109,10 +113,12 @@ export default async function StaffAttendancePage({
       return ca.localeCompare(cb)
     })
 
-  const formattedDate = new Date(selectedDate + 'T12:00:00').toLocaleDateString(
-    'en-GB',
-    { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' },
-  )
+  const formattedDate = formatCalendarDate(selectedDate, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
 
   return (
     <div className="max-w-5xl print:max-w-none">
@@ -208,7 +214,7 @@ export default async function StaffAttendancePage({
                 </td>
                 <td className="border border-gray-400 p-1 text-xs text-gray-700">
                   {record ? (
-                    fmtTime(record.signed_in_at)
+                    formatTimeInSchoolTz(record.signed_in_at)
                   ) : (
                     <span className="block min-w-[80px] border-b border-gray-400">
                       &nbsp;
@@ -217,7 +223,7 @@ export default async function StaffAttendancePage({
                 </td>
                 <td className="border border-gray-400 p-1 text-xs text-gray-700">
                   {record?.signed_out_at ? (
-                    fmtTime(record.signed_out_at)
+                    formatTimeInSchoolTz(record.signed_out_at)
                   ) : (
                     <span className="block min-w-[80px] border-b border-gray-400">
                       &nbsp;

--- a/src/app/portal/staff-attendance/utils.ts
+++ b/src/app/portal/staff-attendance/utils.ts
@@ -1,6 +1,0 @@
-export function fmtTime(ts: string) {
-  // Extract HH:MM directly from the stored timestamp string to avoid
-  // server/client timezone mismatch (server is UTC, browser is local time).
-  const match = ts.match(/T(\d{2}:\d{2})/)
-  return match ? match[1] : ts
-}

--- a/src/lib/datetime.spec.ts
+++ b/src/lib/datetime.spec.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+
+import {
+  datetimeLocalToUtcIso,
+  formatCalendarDate,
+  formatDateInSchoolTz,
+  formatDateTimeInSchoolTz,
+  formatTimeInSchoolTz,
+  nowDatetimeLocalInSchoolTz,
+  nowTimeInSchoolTz,
+  schoolTzToUtcIso,
+  toDatetimeLocalInSchoolTz,
+  todayInSchoolTz,
+} from './datetime'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('schoolTzToUtcIso', () => {
+  it('treats summer (BST) wall-clock as UTC+1', () => {
+    // 15 July 2026 is BST (UTC+1)
+    expect(schoolTzToUtcIso('2026-07-15', '09:00')).toBe(
+      '2026-07-15T08:00:00.000Z',
+    )
+  })
+
+  it('treats winter (GMT) wall-clock as UTC+0', () => {
+    // 15 January 2026 is GMT
+    expect(schoolTzToUtcIso('2026-01-15', '09:00')).toBe(
+      '2026-01-15T09:00:00.000Z',
+    )
+  })
+
+  it('handles the spring-forward boundary', () => {
+    // 29 March 2026 is the day BST starts at 01:00 UTC (clocks jump 01:00 → 02:00).
+    // 10:00 local that day is BST, so UTC is 09:00.
+    expect(schoolTzToUtcIso('2026-03-29', '10:00')).toBe(
+      '2026-03-29T09:00:00.000Z',
+    )
+  })
+
+  it('handles the fall-back boundary', () => {
+    // 25 October 2026 clocks roll back 02:00 → 01:00 local.
+    // 10:00 local is after the transition, so GMT: UTC == local.
+    expect(schoolTzToUtcIso('2026-10-25', '10:00')).toBe(
+      '2026-10-25T10:00:00.000Z',
+    )
+  })
+})
+
+describe('datetimeLocalToUtcIso', () => {
+  it('accepts a datetime-local string (BST)', () => {
+    expect(datetimeLocalToUtcIso('2026-07-15T14:30')).toBe(
+      '2026-07-15T13:30:00.000Z',
+    )
+  })
+
+  it('accepts a datetime-local string with seconds (GMT)', () => {
+    expect(datetimeLocalToUtcIso('2026-01-15T14:30:45')).toBe(
+      '2026-01-15T14:30:45.000Z',
+    )
+  })
+
+  it('rejects malformed input', () => {
+    expect(() => datetimeLocalToUtcIso('not-a-date')).toThrow()
+  })
+})
+
+describe('formatTimeInSchoolTz', () => {
+  it('renders a summer entry the same way year-round', () => {
+    // Entry made at 09:00 on 15 July 2026 (BST) → stored as 08:00Z.
+    const stored = '2026-07-15T08:00:00.000Z'
+
+    // Viewed immediately (still summer) — should display 09:00.
+    expect(formatTimeInSchoolTz(stored)).toBe('09:00')
+
+    // Viewed later in winter — must still display 09:00, not 08:00.
+    // (We pin "now" to a January date to simulate a winter viewer; the
+    // helper ignores "now" because it formats a specific instant in
+    // Europe/London, so this is really a sanity check that the output
+    // does not depend on the current date.)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2027-01-10T12:00:00Z'))
+    expect(formatTimeInSchoolTz(stored)).toBe('09:00')
+  })
+
+  it('renders a winter entry correctly', () => {
+    // 09:00 GMT on 15 Jan 2026 → stored as 09:00Z.
+    expect(formatTimeInSchoolTz('2026-01-15T09:00:00.000Z')).toBe('09:00')
+  })
+
+  it('round-trips wall-clock → UTC → wall-clock across DST', () => {
+    const summerUtc = schoolTzToUtcIso('2026-07-15', '09:30')
+    const winterUtc = schoolTzToUtcIso('2026-01-15', '09:30')
+    expect(formatTimeInSchoolTz(summerUtc)).toBe('09:30')
+    expect(formatTimeInSchoolTz(winterUtc)).toBe('09:30')
+  })
+})
+
+describe('formatDateInSchoolTz', () => {
+  it('does not roll a BST entry back a day when rendered in winter', () => {
+    // 23:30 local on 15 July 2026 (BST) → 22:30Z on 15 July.
+    const stored = schoolTzToUtcIso('2026-07-15', '23:30')
+    expect(stored).toBe('2026-07-15T22:30:00.000Z')
+    expect(formatDateInSchoolTz(stored)).toBe('15/07/2026')
+  })
+})
+
+describe('formatDateTimeInSchoolTz', () => {
+  it('shows a summer entry with its original wall clock when viewed later', () => {
+    const stored = schoolTzToUtcIso('2026-07-15', '14:15')
+    expect(formatDateTimeInSchoolTz(stored)).toBe('15/07/2026, 14:15')
+  })
+})
+
+describe('toDatetimeLocalInSchoolTz', () => {
+  it('round-trips through datetime-local editing in summer', () => {
+    const stored = schoolTzToUtcIso('2026-07-15', '09:45')
+    expect(toDatetimeLocalInSchoolTz(stored)).toBe('2026-07-15T09:45')
+  })
+
+  it('round-trips through datetime-local editing in winter', () => {
+    const stored = schoolTzToUtcIso('2026-01-15', '09:45')
+    expect(toDatetimeLocalInSchoolTz(stored)).toBe('2026-01-15T09:45')
+  })
+})
+
+describe('formatCalendarDate', () => {
+  it('formats a YYYY-MM-DD string without shifting day', () => {
+    expect(formatCalendarDate('2026-07-15')).toBe('15/07/2026')
+  })
+
+  it('passes through intl options', () => {
+    expect(
+      formatCalendarDate('2026-07-15', {
+        weekday: 'long',
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+      }),
+    ).toBe('Wednesday, 15 July 2026')
+  })
+})
+
+describe('todayInSchoolTz', () => {
+  it('returns the London date when UTC has rolled into the next day', () => {
+    // 15 July 2026 23:30 BST == 16 July 2026 is wrong — UTC is still 22:30
+    // on the 15th. But at 00:30Z on 16 July, London is 01:30 BST on 16 July.
+    // Pick an instant that disagrees between UTC and London:
+    // 15 July 2026 23:30 UTC == 16 July 2026 00:30 BST.
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T23:30:00Z'))
+    expect(todayInSchoolTz()).toBe('2026-07-16')
+  })
+
+  it('returns the same day when UTC and London agree (winter)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-15T09:00:00Z'))
+    expect(todayInSchoolTz()).toBe('2026-01-15')
+  })
+})
+
+describe('nowTimeInSchoolTz', () => {
+  it('returns BST wall-clock time in summer', () => {
+    vi.useFakeTimers()
+    // 08:30Z on 15 July 2026 == 09:30 BST.
+    vi.setSystemTime(new Date('2026-07-15T08:30:00Z'))
+    expect(nowTimeInSchoolTz()).toBe('09:30')
+  })
+
+  it('returns GMT wall-clock time in winter', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-15T08:30:00Z'))
+    expect(nowTimeInSchoolTz()).toBe('08:30')
+  })
+})
+
+describe('nowDatetimeLocalInSchoolTz', () => {
+  it('returns a datetime-local string in BST during summer', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-15T08:30:00Z'))
+    expect(nowDatetimeLocalInSchoolTz()).toBe('2026-07-15T09:30')
+  })
+})

--- a/src/lib/datetime.ts
+++ b/src/lib/datetime.ts
@@ -1,0 +1,261 @@
+/**
+ * Date/time helpers for the portal.
+ *
+ * All staff, attendance, incidents, and lesson plan flows interpret user input
+ * as wall-clock time in the school's timezone (Europe/London). Values are
+ * stored in Postgres `timestamptz` as UTC instants and rendered back in
+ * Europe/London — so an entry made at 09:00 BST in July always renders 09:00
+ * regardless of when (or in which season) it is viewed later.
+ *
+ * Use these helpers instead of calling `new Date()`, `toISOString()`,
+ * `toLocaleDateString()`, `toLocaleTimeString()` etc. directly — those rely
+ * on the runtime's timezone and will silently drift by an hour across DST.
+ */
+
+/** IANA zone for the school. Everything the portal shows or stores is anchored here. */
+export const SCHOOL_TIMEZONE = 'Europe/London'
+
+type WallClockParts = {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+}
+
+function partsInSchoolTz(instant: Date): WallClockParts {
+  const dtf = new Intl.DateTimeFormat('en-GB', {
+    timeZone: SCHOOL_TIMEZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+  const map: Record<string, string> = {}
+  for (const p of dtf.formatToParts(instant)) {
+    if (p.type !== 'literal') map[p.type] = p.value
+  }
+  return {
+    year: Number(map.year),
+    month: Number(map.month),
+    day: Number(map.day),
+    // `en-GB` emits "24" instead of "00" at midnight.
+    hour: Number(map.hour) % 24,
+    minute: Number(map.minute),
+    second: Number(map.second),
+  }
+}
+
+function pad2(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/**
+ * Convert a wall-clock date + time in Europe/London to a UTC ISO string.
+ *
+ * Use at the server-action boundary when writing user-entered date/time pairs
+ * (e.g. staff sign-in/out) into a `timestamptz` column. DST is handled from
+ * the entry date, so `09:00` on a summer day becomes `08:00Z` and `09:00` on
+ * a winter day becomes `09:00Z`.
+ *
+ * @param date - `YYYY-MM-DD` calendar date in Europe/London.
+ * @param time - `HH:MM` wall-clock time in Europe/London.
+ * @returns UTC ISO string suitable for Postgres `timestamptz`.
+ */
+export function schoolTzToUtcIso(date: string, time: string): string {
+  return datetimeLocalToUtcIso(`${date}T${time}`)
+}
+
+/**
+ * Convert a `<input type="datetime-local">` value (interpreted as
+ * Europe/London wall-clock) to a UTC ISO string.
+ *
+ * Use at the server-action boundary for fields backed by `datetime-local`
+ * inputs (incidents, parent-notified timestamps). Handles DST the same way
+ * as {@link schoolTzToUtcIso}.
+ *
+ * @param localDateTime - `YYYY-MM-DDTHH:MM` (seconds optional) in London wall-clock.
+ * @returns UTC ISO string suitable for Postgres `timestamptz`.
+ */
+export function datetimeLocalToUtcIso(localDateTime: string): string {
+  const match = localDateTime.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/,
+  )
+  if (!match) throw new Error(`Invalid datetime-local value: ${localDateTime}`)
+  const [, y, mo, d, h, mi, s] = match
+  const target: WallClockParts = {
+    year: Number(y),
+    month: Number(mo),
+    day: Number(d),
+    hour: Number(h),
+    minute: Number(mi),
+    second: Number(s ?? '0'),
+  }
+
+  // Start by assuming the wall-clock numbers are UTC, then correct using the
+  // school-tz offset that applies at that instant. One re-check covers DST
+  // transitions (when the first guess lands on the wrong side of the jump).
+  let guess = Date.UTC(
+    target.year,
+    target.month - 1,
+    target.day,
+    target.hour,
+    target.minute,
+    target.second,
+  )
+  for (let i = 0; i < 2; i++) {
+    const observed = partsInSchoolTz(new Date(guess))
+    const observedUtc = Date.UTC(
+      observed.year,
+      observed.month - 1,
+      observed.day,
+      observed.hour,
+      observed.minute,
+      observed.second,
+    )
+    const targetUtc = Date.UTC(
+      target.year,
+      target.month - 1,
+      target.day,
+      target.hour,
+      target.minute,
+      target.second,
+    )
+    const diff = targetUtc - observedUtc
+    if (diff === 0) break
+    guess += diff
+  }
+  return new Date(guess).toISOString()
+}
+
+/**
+ * Today's calendar date in Europe/London as `YYYY-MM-DD`.
+ *
+ * Use instead of `new Date().toISOString().split('T')[0]` for default dates,
+ * "today/historical/future" comparisons, and anywhere the *school's* current
+ * date matters. The raw ISO approach returns the wrong day after 23:00 local
+ * time in winter and after 00:00 local time in summer, because the server
+ * clock is UTC.
+ */
+export function todayInSchoolTz(): string {
+  const p = partsInSchoolTz(new Date())
+  return `${p.year}-${pad2(p.month)}-${pad2(p.day)}`
+}
+
+/**
+ * Current wall-clock time in Europe/London as `HH:MM`.
+ *
+ * Use as the `defaultValue` for `<input type="time">` (e.g. the staff sign-in
+ * form) so the prefilled time matches the user's local clock rather than the
+ * server's UTC clock.
+ */
+export function nowTimeInSchoolTz(): string {
+  const p = partsInSchoolTz(new Date())
+  return `${pad2(p.hour)}:${pad2(p.minute)}`
+}
+
+/**
+ * Current moment in Europe/London formatted as `YYYY-MM-DDTHH:MM`.
+ *
+ * Use as the `defaultValue` for `<input type="datetime-local">` inputs
+ * (incidents, parent-notified time). Replaces the ad-hoc
+ * `new Date(... - getTimezoneOffset())` pattern which depends on the
+ * *browser's* timezone and is server-rendered incorrectly.
+ */
+export function nowDatetimeLocalInSchoolTz(): string {
+  const p = partsInSchoolTz(new Date())
+  return `${p.year}-${pad2(p.month)}-${pad2(p.day)}T${pad2(p.hour)}:${pad2(p.minute)}`
+}
+
+/**
+ * Convert a stored UTC timestamp to `YYYY-MM-DDTHH:MM` in Europe/London for
+ * populating `<input type="datetime-local">` when editing a record.
+ *
+ * Use instead of `value.slice(0, 16)` — the slice only works accidentally
+ * when the value was stored wall-clock-as-UTC, and breaks as soon as storage
+ * is correct.
+ */
+export function toDatetimeLocalInSchoolTz(utcIso: string): string {
+  const p = partsInSchoolTz(new Date(utcIso))
+  return `${p.year}-${pad2(p.month)}-${pad2(p.day)}T${pad2(p.hour)}:${pad2(p.minute)}`
+}
+
+/**
+ * Format a stored UTC timestamp as `HH:MM` in Europe/London.
+ *
+ * Use for sign-in/sign-out badges and any time-only display of a stored
+ * `timestamptz` value. Output is stable across DST: an entry made at 09:00
+ * in summer will still display 09:00 when viewed in winter.
+ */
+export function formatTimeInSchoolTz(utcIso: string): string {
+  const p = partsInSchoolTz(new Date(utcIso))
+  return `${pad2(p.hour)}:${pad2(p.minute)}`
+}
+
+/**
+ * Format a stored UTC timestamp as a date in Europe/London.
+ *
+ * Use for rendering `timestamptz` columns like `incident_date` where the
+ * calendar-day of the entry must not drift across DST. Defaults to
+ * `en-GB` short date; pass options for weekday/long month etc.
+ */
+export function formatDateInSchoolTz(
+  utcIso: string,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: SCHOOL_TIMEZONE,
+    ...options,
+  }).format(new Date(utcIso))
+}
+
+/**
+ * Format a stored UTC timestamp as a full date-and-time in Europe/London.
+ *
+ * Use for audit-ish lines like "Created on ... by ..." where both date and
+ * time matter. Replaces `new Date(ts).toLocaleString('en-GB')`, which uses
+ * the viewer's local timezone.
+ */
+export function formatDateTimeInSchoolTz(utcIso: string): string {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: SCHOOL_TIMEZONE,
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(utcIso))
+}
+
+/**
+ * Format a date-only string (`YYYY-MM-DD`, e.g. `lesson_date`, `attendance.date`)
+ * for display. The string has no timezone semantics — this helper just parses
+ * the components and formats them via `Intl.DateTimeFormat` without any
+ * instant-based conversion, so the rendered day always matches the stored day.
+ *
+ * Use for fields stored as `DATE` / `YYYY-MM-DD` strings. Do NOT use for
+ * `timestamptz` values — use {@link formatDateInSchoolTz} for those.
+ *
+ * @param dateStr - `YYYY-MM-DD`.
+ * @param options - passed through to `Intl.DateTimeFormat` (`en-GB`).
+ */
+export function formatCalendarDate(
+  dateStr: string,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!match) return dateStr
+  const [, y, m, d] = match
+  // Anchor at noon UTC so any later timezone-aware formatting still resolves
+  // to the same calendar day for UK-adjacent zones.
+  const instant = new Date(Date.UTC(Number(y), Number(m) - 1, Number(d), 12))
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: SCHOOL_TIMEZONE,
+    ...options,
+  }).format(instant)
+}


### PR DESCRIPTION
review the usage of date and times. for the staff sign, it need to be viewed and saved in the timezone of the day. for example today it is summer time and all the times are wrong. 
it should reflect the signed in time of day and when looking at it later it shouldnt convert. You shouldnt see sign in recorded during the winter move by an hour when timezone changes. 