### PR TITLE
perf/a11y: image priority, sizing, and color contrast (Lighthouse phases 1 & 2)

### DIFF
--- a/src/app/portal/_components/PortalSidebar.tsx
+++ b/src/app/portal/_components/PortalSidebar.tsx
@@ -168,7 +168,13 @@ export default function PortalSidebar({
           title="Go to main site"
           className="transition-transform duration-150 hover:scale-110 active:scale-95"
         >
-          <Image src={logo} alt="HSHB Logo" className="h-7 w-auto" />
+          <Image
+            src={logo}
+            alt="HSHB Logo"
+            className="h-7 w-auto"
+            width={28}
+            height={28}
+          />
         </Link>
         <span className="text-sm font-semibold text-white">Staff Portal</span>
       </div>
@@ -195,7 +201,13 @@ export default function PortalSidebar({
               title="Go to main site"
               className="transition-transform duration-150 hover:scale-110 active:scale-95"
             >
-              <Image src={logo} alt="HSHB Logo" className="h-7 w-auto" />
+              <Image
+                src={logo}
+                alt="HSHB Logo"
+                className="h-7 w-auto"
+                width={28}
+                height={28}
+              />
             </Link>
             <span className="text-sm font-semibold text-white">
               Staff Portal
@@ -221,7 +233,13 @@ export default function PortalSidebar({
             title="Go to main site"
             className="transition-transform duration-150 hover:scale-110 active:scale-95"
           >
-            <Image src={logo} alt="HSHB Logo" className="h-8 w-auto" />
+            <Image
+              src={logo}
+              alt="HSHB Logo"
+              className="h-8 w-auto"
+              width={32}
+              height={32}
+            />
           </Link>
           <div>
             <p className="text-sm font-semibold text-white">HSHB</p>

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -138,14 +138,26 @@ function SidebarLoadingSkeleton() {
       {/* Mobile top bar */}
       <div className="fixed inset-x-0 top-0 z-40 flex h-14 items-center gap-3 bg-gray-900 px-4 md:hidden print:hidden">
         <div className="h-6 w-6 rounded bg-gray-700" />
-        <Image src={logo} alt="HSHB Logo" className="h-7 w-auto" />
+        <Image
+          src={logo}
+          alt="HSHB Logo"
+          className="h-7 w-auto"
+          width={28}
+          height={28}
+        />
         <span className="text-sm font-semibold text-white">Staff Portal</span>
       </div>
 
       {/* Desktop sidebar */}
       <aside className="sticky top-0 hidden h-screen w-64 shrink-0 flex-col bg-gray-900 md:flex print:hidden">
         <div className="flex items-center gap-3 border-b border-gray-700 px-5 py-4">
-          <Image src={logo} alt="HSHB Logo" className="h-8 w-auto" />
+          <Image
+            src={logo}
+            alt="HSHB Logo"
+            className="h-8 w-auto"
+            width={32}
+            height={32}
+          />
           <div>
             <p className="text-sm font-semibold text-white">HSHB</p>
             <p className="text-xs text-gray-400">Staff Portal</p>

--- a/src/app/portal/login/page.tsx
+++ b/src/app/portal/login/page.tsx
@@ -23,7 +23,7 @@ export default async function LoginPage({
     <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
       <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-lg ring-1 ring-gray-200 sm:p-8">
         <div className="mb-8 flex flex-col items-center gap-3">
-          <Image src={logo} alt="HSHB Logo" className="h-12 w-auto" />
+          <Image src={logo} alt="HSHB Logo" className="h-12 w-auto" priority />
           <div className="text-center">
             <h1 className="text-xl font-bold text-gray-900">Staff Portal</h1>
             <p className="mt-1 text-sm text-gray-500">

--- a/src/clientComponents/FeaturedQuoteSelector.spec.tsx
+++ b/src/clientComponents/FeaturedQuoteSelector.spec.tsx
@@ -65,4 +65,11 @@ describe('FeaturedQuoteSelector', () => {
     unmount()
     expect(clearIntervalSpy).toHaveBeenCalled()
   })
+
+  it('figcaption uses text-slate-600 for sufficient color contrast', () => {
+    render(<FeaturedQuoteSelector items={mockQuotes} />)
+    const figcaption = document.querySelector('figcaption')
+    expect(figcaption?.className).toContain('text-slate-600')
+    expect(figcaption?.className).not.toContain('text-slate-500')
+  })
 })

--- a/src/clientComponents/FeaturedQuoteSelector.tsx
+++ b/src/clientComponents/FeaturedQuoteSelector.tsx
@@ -13,7 +13,7 @@ const FeaturedQuoteComp: FC<{ quote?: FeaturedQuote }> = ({ quote }) => {
           {quote?.text}
         </p>
       </blockquote>
-      <figcaption className="mt-2 text-sm text-slate-500">
+      <figcaption className="mt-2 text-sm text-slate-600">
         <strong className="pr-1 font-semibold text-blue-600 before:content-['—_']">
           {quote?.author}
         </strong>

--- a/src/sections/Community.tsx
+++ b/src/sections/Community.tsx
@@ -106,7 +106,7 @@ export const Community = (props: Props) => {
                             'font-mono text-sm',
                             groupIndex === selectedIndex
                               ? 'text-blue-600'
-                              : 'text-slate-500',
+                              : 'text-slate-600',
                           )}
                         >
                           <Tab className="ui-not-focus-visible:outline-none">
@@ -183,7 +183,7 @@ export const Community = (props: Props) => {
                       <h3 className="font-display mt-8 text-xl font-bold tracking-tight text-slate-900">
                         {person.name}
                       </h3>
-                      <div className="mt-1 text-base tracking-tight text-slate-500">
+                      <div className="mt-1 text-base tracking-tight text-slate-600">
                         <ReactMarkdown remarkPlugins={[remarkGfm]}>
                           {person.blurb}
                         </ReactMarkdown>

--- a/src/sections/Events.tsx
+++ b/src/sections/Events.tsx
@@ -9,7 +9,7 @@ const PlaceholderImage = () => {
   return (
     <div className="absolute inset-0 flex items-center justify-center">
       <div className="absolute inset-0 flex items-center justify-center bg-[#6366F1]">
-        <Image src={discordImage} alt="" />
+        <Image src={discordImage} alt="" width={80} height={72} />
       </div>
     </div>
   )

--- a/src/sections/Footer.tsx
+++ b/src/sections/Footer.tsx
@@ -18,7 +18,13 @@ export function Footer() {
           className="flex gap-1 rounded-md px-2 py-1 hover:bg-gray-400 hover:text-white"
           title="Contribute to our website!"
         >
-          <Image priority src={github} height={24} alt="Github Link" />
+          <Image
+            priority
+            src={github}
+            height={24}
+            width={24}
+            alt="Github Link"
+          />
           <span>Contribute</span>
         </a>
 

--- a/src/sections/Hero.tsx
+++ b/src/sections/Hero.tsx
@@ -12,7 +12,13 @@ export const Hero = (props: Props) => {
         <div className="relative flex items-center lg:col-span-5 lg:row-span-2">
           <div className="rounded-br-6xl absolute -top-20 right-1/2 -bottom-12 left-0 z-10 bg-blue-800 text-white/10 md:bottom-8 lg:-inset-y-12 lg:right-full lg:left-[-100vw] lg:-mr-40" />
           <div className="relative z-10 mx-auto flex w-64 pt-12 md:w-80 lg:pt-24">
-            <Image className="w-full" src={logo} alt="" placeholder="blur" />
+            <Image
+              className="w-full"
+              src={logo}
+              alt=""
+              placeholder="blur"
+              priority
+            />
           </div>
         </div>
         <div className="relative px-4 py-6 pb-0 sm:px-6 md:py-0 lg:col-span-7 lg:pt-0 lg:pr-0 lg:pb-8 lg:pl-16">

--- a/src/sections/Navbar.tsx
+++ b/src/sections/Navbar.tsx
@@ -120,7 +120,12 @@ export const Navbar = () => {
               className="flex shrink-0 items-center"
               onClick={() => onLinkClick('home')}
             >
-              <Image src={logo} alt="HSHB Logo" className="h-8 w-auto" />
+              <Image
+                src={logo}
+                alt="HSHB Logo"
+                className="h-8 w-auto"
+                priority
+              />
             </a>
             <div className="hidden sm:ml-6 sm:block">
               <div className="flex space-x-4">
@@ -199,6 +204,7 @@ export const Navbar = () => {
                 priority
                 src={classdojoSmall}
                 height={28}
+                width={30}
                 alt="Parents Login"
               />
               <span className="hidden lg:inline">Parents</span>


### PR DESCRIPTION
## Summary

- **Phase 1 — Image performance (LCP + CLS):** Adds `priority` to above-fold `<Image>` components so Next.js emits a preload link instead of lazy-loading the LCP element (was 6.1 s). Adds explicit `width`/`height` to all images that were missing dimensions, preventing layout shift.
- **Phase 2 — Accessibility:** Bumps `text-slate-500` → `text-slate-600` on the hero figcaption and community section text to meet WCAG AA 4.5:1 contrast minimum (was 4.3:1). Guards the fix with a spec assertion.

## Files changed

| File | Change |
|------|--------|
| `src/sections/Hero.tsx` | `priority` on logo (LCP fix) |
| `src/sections/Navbar.tsx` | `priority` on logo; `width={30}` on ClassDojo icon |
| `src/sections/Events.tsx` | `width`/`height` on Discord placeholder SVG |
| `src/sections/Footer.tsx` | `width={24}` on GitHub icon |
| `src/app/portal/login/page.tsx` | `priority` on login page logo |
| `src/app/portal/layout.tsx` | Explicit dimensions on sidebar skeleton logos |
| `src/app/portal/_components/PortalSidebar.tsx` | Explicit dimensions on all sidebar logos |
| `src/clientComponents/FeaturedQuoteSelector.tsx` | `text-slate-500` → `text-slate-600` on figcaption |
| `src/clientComponents/FeaturedQuoteSelector.spec.tsx` | Assertion guarding contrast class |
| `src/sections/Community.tsx` | `text-slate-500` → `text-slate-600` on tab labels and blurb text |

## Test plan

- [x] `npm run lint` — warnings only (pre-existing), no errors
- [x] `npm run format:check` — clean
- [x] `npm run type-check` — clean
- [x] `npm run test:coverage` — 1007 tests passed, thresholds met
- [x] `npm run test:e2e` — 156 passed, 16 skipped
- [x] `npm run build` — clean production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)