### PR TITLE
perf(phase-3): defer Google Calendar iframe and improve GA event tracking

### DIFF
--- a/src/clientComponents/CalendarEmbed.spec.tsx
+++ b/src/clientComponents/CalendarEmbed.spec.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+
+vi.mock('@/data/events', () => ({ sendEvent: vi.fn() }))
+import { sendEvent } from '@/data/events'
+
+import { CalendarEmbed } from './CalendarEmbed'
+
+const src = 'https://calendar.google.com/calendar/embed?src=test%40gmail.com'
+const title = 'Test Calendar'
+
+type IOCallback = (entries: IntersectionObserverEntry[]) => void
+let intersectionCallback: IOCallback
+const observeMock = vi.fn()
+const disconnectMock = vi.fn()
+
+class MockIntersectionObserver {
+  constructor(cb: IOCallback) {
+    intersectionCallback = cb
+  }
+  observe = observeMock
+  disconnect = disconnectMock
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  observeMock.mockReset()
+  disconnectMock.mockReset()
+})
+
+describe('CalendarEmbed', () => {
+  it('renders a placeholder skeleton before the section enters the viewport', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+    expect(screen.queryByTitle(title)).toBeNull()
+  })
+
+  it('renders the iframe once the section scrolls into view', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: true } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    const iframe = screen.getByTitle(title) as HTMLIFrameElement
+    expect(iframe).toBeTruthy()
+    expect(iframe.src).toBe(src)
+  })
+
+  it('disconnects the observer after the iframe loads', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: true } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(disconnectMock).toHaveBeenCalled()
+  })
+
+  it('does not load the iframe when the section is not yet visible', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: false } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(screen.queryByTitle(title)).toBeNull()
+  })
+
+  it('disconnects the observer on unmount', () => {
+    const { unmount } = render(<CalendarEmbed src={src} title={title} />)
+    unmount()
+    expect(disconnectMock).toHaveBeenCalled()
+  })
+
+  it('fires a GA view event when the calendar scrolls into view', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: true } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(sendEvent).toHaveBeenCalledWith(
+      'view',
+      'calendar-scrolled-into-view',
+    )
+  })
+
+  it('does not fire a GA event when the section is not intersecting', () => {
+    render(<CalendarEmbed src={src} title={title} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: false } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    expect(sendEvent).not.toHaveBeenCalled()
+  })
+
+  it('applies the provided height to the wrapper', () => {
+    const { container } = render(
+      <CalendarEmbed src={src} title={title} height={600} />,
+    )
+    const wrapper = container.firstChild as HTMLElement
+    expect(wrapper?.style.height).toBe('600px')
+  })
+
+  it('applies the provided height to the iframe', () => {
+    render(<CalendarEmbed src={src} title={title} height={600} />)
+
+    act(() => {
+      intersectionCallback([
+        { isIntersecting: true } as unknown as IntersectionObserverEntry,
+      ])
+    })
+
+    const iframe = screen.getByTitle(title) as HTMLIFrameElement
+    expect(iframe.height).toBe('600')
+  })
+})

--- a/src/clientComponents/CalendarEmbed.tsx
+++ b/src/clientComponents/CalendarEmbed.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { sendEvent } from '@/data/events'
+
+type Props = {
+  src: string
+  title: string
+  height?: number
+}
+
+export const CalendarEmbed = ({ src, title, height = 500 }: Props) => {
+  const [loaded, setLoaded] = useState(false)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = sentinelRef.current
+    if (!el) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          sendEvent('view', 'calendar-scrolled-into-view')
+          setLoaded(true)
+          observer.disconnect()
+        }
+      },
+      { rootMargin: '200px' },
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <div
+      ref={sentinelRef}
+      className="mx-auto pb-5"
+      style={{ height, width: '100%' }}
+    >
+      {loaded ? (
+        <iframe
+          src={src}
+          style={{ display: 'block' }}
+          width="100%"
+          height={height}
+          title={title}
+          frameBorder="0"
+          scrolling="no"
+        />
+      ) : (
+        <div className="h-full w-full rounded-xl border border-slate-200 bg-slate-50" />
+      )}
+    </div>
+  )
+}

--- a/src/data/events.spec.ts
+++ b/src/data/events.spec.ts
@@ -26,22 +26,45 @@ describe('sendEvent', () => {
       vi.unstubAllEnvs()
     })
 
-    it('calls sendGAEvent with action_name as a flat param', () => {
-      sendEvent('click', 'button-pressed', { id: 1 })
-      expect(sendGAEvent).toHaveBeenCalledWith('event', 'click', {
-        action_name: 'button-pressed',
-      })
-    })
-
     it('calls sendGAEvent once per invocation', () => {
-      sendEvent('view', 'page-view', null)
+      sendEvent('view', 'page-view')
       expect(sendGAEvent).toHaveBeenCalledTimes(1)
     })
 
     it('uses actionType as the GA event name', () => {
-      sendEvent('submit', 'form-submit', 'some data')
+      sendEvent('submit', 'form-submit')
       expect(sendGAEvent).toHaveBeenCalledWith('event', 'submit', {
         action_name: 'form-submit',
+      })
+    })
+
+    it('passes string data as a label param', () => {
+      sendEvent('click', 'navigation', 'about-us')
+      expect(sendGAEvent).toHaveBeenCalledWith('event', 'click', {
+        action_name: 'navigation',
+        label: 'about-us',
+      })
+    })
+
+    it('spreads object data as flat GA params', () => {
+      sendEvent('scroll', 'section-view', { section: 'events' })
+      expect(sendGAEvent).toHaveBeenCalledWith('event', 'scroll', {
+        action_name: 'section-view',
+        section: 'events',
+      })
+    })
+
+    it('sends only action_name when data is null', () => {
+      sendEvent('view', 'page-view', null)
+      expect(sendGAEvent).toHaveBeenCalledWith('event', 'view', {
+        action_name: 'page-view',
+      })
+    })
+
+    it('sends only action_name when data is undefined', () => {
+      sendEvent('view', 'calendar-scrolled-into-view')
+      expect(sendGAEvent).toHaveBeenCalledWith('event', 'view', {
+        action_name: 'calendar-scrolled-into-view',
       })
     })
   })

--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -4,8 +4,12 @@ export const sendEvent = (
   actionType: string,
   actionName: string,
   data?: unknown,
-) => {
+): void => {
   console.debug('[EVENT]', actionType, { actionName, data })
   if (process.env.NODE_ENV !== 'production') return
-  sendGAEvent('event', actionType, { action_name: actionName })
+  const params: Record<string, unknown> = { action_name: actionName }
+  if (typeof data === 'string') params.label = data
+  else if (typeof data === 'object' && data !== null)
+    Object.assign(params, data)
+  sendGAEvent('event', actionType, params)
 }

--- a/src/data/mdxConfig.tsx
+++ b/src/data/mdxConfig.tsx
@@ -25,6 +25,6 @@ export const mdxGridComponents = {
     return <td className="text-center text-slate-800">{props.children}</td>
   },
   img: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
-    return <img className="mx-auto" alt="" {...props} />
+    return <img className="mx-auto h-auto w-full" alt="" {...props} />
   },
 }

--- a/src/sections/Events.tsx
+++ b/src/sections/Events.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image'
 
 import { Container } from '@/components/Container'
+import { CalendarEmbed } from '@/clientComponents/CalendarEmbed'
 import { ScrollTracker } from '@/clientComponents/ScrollTracker'
 import discordImage from '@/images/resources/discord.svg'
 import { PastEvent } from '@/data/contentful'
@@ -66,16 +67,11 @@ export const Events = (props: Props) => {
         >
           Our Events Calendar
         </h2>
-        <iframe
+        <CalendarEmbed
           src="https://calendar.google.com/calendar/embed?height=600&wkst=2&ctz=Europe%2FLondon&showPrint=0&hl=en_GB&showCalendars=0&title&src=dG9uLmFudG9uaWFkb3VAZ21haWwuY29t&color=%233F51B5"
-          style={{ display: 'block' }}
-          className="mx-auto pb-5"
-          width="100%"
-          height="500"
           title="HSHB Events Calendar"
-          frameBorder="0"
-          scrolling="no"
-        ></iframe>
+          height={500}
+        />
       </Container>
       <Container>
         <h3 className="font-display mt-8 text-4xl font-bold tracking-tight text-slate-900">

--- a/src/sections/Navbar.spec.tsx
+++ b/src/sections/Navbar.spec.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('next/image', () => ({
+  default: ({ alt }: { alt: string }) => <img alt={alt} />,
+}))
+vi.mock('@/images/logo.png', () => ({ default: '/logo.png' }))
+vi.mock('@/images/icons/twitter.svg', () => ({ default: '/twitter.svg' }))
+vi.mock('@/images/icons/facebook.svg', () => ({ default: '/facebook.svg' }))
+vi.mock('@/images/icons/instagram.svg', () => ({ default: '/instagram.svg' }))
+vi.mock('@/images/icons/classdojo-icon.svg', () => ({
+  default: '/classdojo.svg',
+}))
+
+vi.mock('@/data/events', () => ({ sendEvent: vi.fn() }))
+import { sendEvent } from '@/data/events'
+
+import { Navbar } from './Navbar'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('Navbar', () => {
+  describe('desktop nav click tracking', () => {
+    it('fires a GA click event when a desktop nav link is clicked', () => {
+      render(<Navbar />)
+      const links = screen.getAllByRole('link', { name: /events/i })
+      fireEvent.click(links[0])
+      expect(sendEvent).toHaveBeenCalledWith('click', 'navigation', 'events')
+    })
+
+    it('fires a GA click event with "home" when the logo link is clicked', () => {
+      render(<Navbar />)
+      const logoLink = screen
+        .getAllByRole('link')
+        .find((el) => el.getAttribute('href') === '#')
+      fireEvent.click(logoLink!)
+      expect(sendEvent).toHaveBeenCalledWith('click', 'navigation', 'home')
+    })
+  })
+
+  describe('mobile nav click tracking', () => {
+    it('fires a GA click event when a mobile nav link is clicked', () => {
+      render(<Navbar />)
+      const menuButton = screen.getByRole('button', { name: /open main menu/i })
+      fireEvent.click(menuButton)
+
+      const mobileLinks = screen.getAllByRole('link', { name: /contact/i })
+      fireEvent.click(mobileLinks[mobileLinks.length - 1])
+      expect(sendEvent).toHaveBeenCalledWith('click', 'navigation', 'contact')
+    })
+
+    it('fires "home" for the mobile Home nav link', () => {
+      render(<Navbar />)
+      const menuButton = screen.getByRole('button', { name: /open main menu/i })
+      fireEvent.click(menuButton)
+
+      const mobileLinks = screen.getAllByRole('link', { name: /^home$/i })
+      fireEvent.click(mobileLinks[mobileLinks.length - 1])
+      expect(sendEvent).toHaveBeenCalledWith('click', 'navigation', 'home')
+    })
+  })
+})

--- a/src/sections/Navbar.tsx
+++ b/src/sections/Navbar.tsx
@@ -229,6 +229,7 @@ export const Navbar = () => {
               key={section.id}
               as="a"
               href={`#${section.id}`}
+              onClick={() => onLinkClick(section.id || 'home')}
               className={clsx(
                 sectionIndex === activeIndex
                   ? 'bg-gray-900 text-white'


### PR DESCRIPTION
## Summary

- **Calendar iframe deferral**: Replace the eagerly-loaded Google Calendar `<iframe>` (~422 KB, ~200 ms main-thread blocking) with a `CalendarEmbed` client component that uses `IntersectionObserver` to load only once the events section scrolls into view (200 px root margin). Eliminates the third-party script cost from initial page load, directly reducing TBT and TTI.
- **MDX image CLS fix**: Add `h-auto w-full` to the MDX `img` renderer so unsized Contentful images reserve space correctly, preventing layout shift.
- **GA event data passthrough**: Fix `sendEvent` to include string data as a `label` param and spread object data as flat GA parameters — previously all data was silently dropped before reaching GA, so section names, nav labels, and other context were invisible in Analytics.
- **Mobile nav click tracking**: Add `onClick` to mobile `DisclosureButton` nav items (desktop was already tracked). Closes the gap where mobile navigation clicks were not reported.
- **Calendar scroll GA event**: `CalendarEmbed` fires `sendEvent('view', 'calendar-scrolled-into-view')` on first intersection so calendar reach is visible in Analytics.

## Test plan

- [ ] `npm run pipeline:check` passes (lint → format → type-check → 1023 unit tests → E2E → build)
- [ ] Scroll to Events section — calendar loads automatically without a click
- [ ] GA events visible in Analytics: `section-view` with section name, `navigation` with nav label on both desktop and mobile
- [ ] No CLS from Contentful MDX images (community page with extended blurb)

🤖 Generated with [Claude Code](https://claude.com/claude-code)