### PR TITLE
perf(layout): defer Fontshare CSS to unblock FCP and LCP

### DIFF
--- a/src/app/layout.spec.tsx
+++ b/src/app/layout.spec.tsx
@@ -9,6 +9,10 @@ vi.mock('@next/third-parties/google', () => ({
   GoogleAnalytics: () => null,
 }))
 
+vi.mock('@/clientComponents/FontLoader', () => ({
+  FontLoader: () => null,
+}))
+
 vi.mock('@/styles/tailwind.css', () => ({}))
 
 vi.mock('clsx', () => ({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { GoogleAnalytics } from '@next/third-parties/google'
 import clsx from 'clsx'
 
 import '../styles/tailwind.css'
+import { FontLoader } from '@/clientComponents/FontLoader'
+
 import IosSplashLinks from './portal/_components/IosSplashLinks'
 
 const inter = Inter({
@@ -76,12 +78,14 @@ export default function RootLayout({
           href="https://cdn.fontshare.com"
           crossOrigin="anonymous"
         />
-        <link
-          rel="stylesheet"
-          href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@800,500,700&display=swap"
-        />
+        <link rel="dns-prefetch" href="https://api.fontshare.com" />
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
       </head>
-      <body className="flex min-h-full flex-col">{children}</body>
+      <body className="flex min-h-full flex-col">
+        {children}
+        <FontLoader />
+      </body>
       {process.env.NODE_ENV === 'production' && (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID!} />
       )}

--- a/src/clientComponents/FontLoader.spec.tsx
+++ b/src/clientComponents/FontLoader.spec.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+
+import { FontLoader } from './FontLoader'
+
+afterEach(() => {
+  document.head
+    .querySelectorAll('link[data-fontloader]')
+    .forEach((el) => el.remove())
+})
+
+describe('FontLoader', () => {
+  it('renders nothing visible', () => {
+    const { container } = render(<FontLoader />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('appends a stylesheet link to the document head after mount', async () => {
+    await act(async () => {
+      render(<FontLoader />)
+    })
+
+    const links = Array.from(
+      document.head.querySelectorAll('link[rel="stylesheet"]'),
+    )
+    const fontLink = links.find((el) =>
+      el.getAttribute('href')?.includes('fontshare.com'),
+    )
+    expect(fontLink).toBeTruthy()
+  })
+
+  it('sets the href to the Cabinet Grotesk fontshare URL', async () => {
+    await act(async () => {
+      render(<FontLoader />)
+    })
+
+    const links = Array.from(
+      document.head.querySelectorAll('link[rel="stylesheet"]'),
+    )
+    const fontLink = links.find((el) =>
+      el.getAttribute('href')?.includes('fontshare.com'),
+    )
+    expect(fontLink?.getAttribute('href')).toContain('cabinet-grotesk')
+    expect(fontLink?.getAttribute('href')).toContain('display=swap')
+  })
+})

--- a/src/clientComponents/FontLoader.tsx
+++ b/src/clientComponents/FontLoader.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export const FontLoader = (): null => {
+  useEffect(() => {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href =
+      'https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@800,500,700&display=swap'
+    document.head.appendChild(link)
+  }, [])
+
+  return null
+}


### PR DESCRIPTION
## Summary

- **Remove render-blocking Fontshare CSS**: The `<link rel="stylesheet">` for Cabinet Grotesk was loading synchronously in `<head>`, blocking all paint for ~321 ms. Replaced with `FontLoader` — a client component that appends the stylesheet after hydration via `useEffect`. Cabinet Grotesk falls back to `ui-sans-serif` during load; `display: swap` is already set in the Fontshare URL so text renders immediately in the fallback.
- **Expected LCP improvement**: The large heading text (most likely the LCP candidate) was only painting in Cabinet Grotesk *after* the Fontshare CSS finished loading, creating the 2 s gap between FCP and LCP. Deferring the CSS should collapse LCP much closer to FCP (~2 s → could reach ~2 s).
- **Keep `<GoogleAnalytics>` from `@next/third-parties/google`**: Intentionally retained — the library uses `afterInteractive` for good reason (reliable tracking from first interaction, dataLayer queue handles early events). Rolling our own `lazyOnload` implementation gains ~118 ms at the cost of losing maintained library integration.
- **Preconnect hints**: Added `preconnect` + `dns-prefetch` for Fontshare and GTM domains to reduce connection setup time when those resources load.

## Test plan

- [ ] `npm run pipeline:check` passes (111 test files, 1026 tests, E2E, build)
- [ ] Page renders immediately in system font; Cabinet Grotesk swaps in shortly after (acceptable FOUT)
- [ ] GA events still fire correctly in production (library unchanged)
- [ ] Run Lighthouse — expect FCP and LCP to both drop significantly, performance score to improve

🤖 Generated with [Claude Code](https://claude.com/claude-code)