### PR TITLE
feat(navbar): redirect staff portal button to portal.hshb.org.uk

### DIFF
--- a/src/sections/Navbar.tsx
+++ b/src/sections/Navbar.tsx
@@ -210,7 +210,7 @@ export const Navbar = () => {
               <span className="hidden lg:inline">Parents</span>
             </a>
             <a
-              href="/portal/login"
+              href="https://portal.hshb.org.uk"
               title="Staff Portal"
               className="flex items-center gap-1 rounded-md px-2 py-2 text-sm font-medium hover:bg-gray-700 hover:text-white"
               onClick={() => onLinkClick('staff-portal')}


### PR DESCRIPTION
## Summary
- Updates the Staff portal button in the navbar from `/portal/login` to `https://portal.hshb.org.uk`
- Portal has been migrated to its own Netlify project at the new domain

## Test plan
- [ ] Click the Staff button in the navbar — should open `https://portal.hshb.org.uk` (new tab or same tab depending on browser)
- [ ] Verify login flow works on the new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)